### PR TITLE
chore: release v0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,17 @@ members = [
 ]
 [workspace.package]
 authors = ["Per Johansson <per@doom.fisn>"]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 repository = "https://github.com/doom-fish/core-frameworks"
 homepage = "https://doom.fish"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-core-audio-types-rs = { path = "crates/core-audio-types-rs", version = "0.2.1" }
-core-media-rs = { path = "crates/core-media-rs", version = "0.2.1" }
-core-video-rs = { path = "crates/core-video-rs", version = "0.2.1" }
-core-utils-rs = { path = "crates/core-utils-rs", version = "0.2.1" }
+core-audio-types-rs = { path = "crates/core-audio-types-rs", version = "0.2.2" }
+core-media-rs = { path = "crates/core-media-rs", version = "0.2.2" }
+core-video-rs = { path = "crates/core-video-rs", version = "0.2.2" }
+core-utils-rs = { path = "crates/core-utils-rs", version = "0.2.2" }
 
 # External dependencies
 core-foundation = "0.10"

--- a/crates/core-audio-types-rs/CHANGELOG.md
+++ b/crates/core-audio-types-rs/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/core-media-rs/CHANGELOG.md
+++ b/crates/core-media-rs/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2](https://github.com/doom-fish/core-frameworks/compare/core-media-rs-v0.2.1...core-media-rs-v0.2.2) - 2024-11-16
+
+### Added
+
+- add descriptions

--- a/crates/core-utils-rs/CHANGELOG.md
+++ b/crates/core-utils-rs/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/core-video-rs/CHANGELOG.md
+++ b/crates/core-video-rs/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2](https://github.com/doom-fish/core-frameworks/compare/core-video-rs-v0.2.1...core-video-rs-v0.2.2) - 2024-11-16
+
+### Added
+
+- add descriptions


### PR DESCRIPTION
## 🤖 New release
* `core-audio-types-rs`: 0.2.1 -> 0.2.2
* `core-media-rs`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `core-utils-rs`: 0.2.1 -> 0.2.2
* `core-video-rs`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `core-media-rs`
<blockquote>

## [0.2.2](https://github.com/doom-fish/core-frameworks/compare/core-media-rs-v0.2.1...core-media-rs-v0.2.2) - 2024-11-16

### Added

- add descriptions
</blockquote>

## `core-video-rs`
<blockquote>

## [0.2.2](https://github.com/doom-fish/core-frameworks/compare/core-video-rs-v0.2.1...core-video-rs-v0.2.2) - 2024-11-16

### Added

- add descriptions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).