### PR TITLE
chore: release v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,17 @@ members = [
 ]
 [workspace.package]
 authors = ["Per Johansson <per@doom.fisn>"]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 repository = "https://github.com/doom-fish/core-frameworks"
 homepage = "https://doom.fish"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-core-audio-types-rs = { path = "crates/core-audio-types-rs", version = "0.2.2" }
-core-media-rs = { path = "crates/core-media-rs", version = "0.2.2" }
-core-video-rs = { path = "crates/core-video-rs", version = "0.2.2" }
-core-utils-rs = { path = "crates/core-utils-rs", version = "0.2.2" }
+core-audio-types-rs = { path = "crates/core-audio-types-rs", version = "0.3.0" }
+core-media-rs = { path = "crates/core-media-rs", version = "0.3.0" }
+core-video-rs = { path = "crates/core-video-rs", version = "0.3.0" }
+core-utils-rs = { path = "crates/core-utils-rs", version = "0.3.0" }
 
 # External dependencies
 core-foundation = "0.10"

--- a/crates/core-media-rs/CHANGELOG.md
+++ b/crates/core-media-rs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/doom-fish/core-frameworks/compare/core-media-rs-v0.2.2...core-media-rs-v0.3.0) - 2024-11-29
+
+### Added
+
+- [**breaking**] adapt for gstreamer
+
 ## [0.2.2](https://github.com/doom-fish/core-frameworks/compare/core-media-rs-v0.2.1...core-media-rs-v0.2.2) - 2024-11-16
 
 ### Added

--- a/crates/core-utils-rs/CHANGELOG.md
+++ b/crates/core-utils-rs/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.0](https://github.com/doom-fish/core-frameworks/compare/core-utils-rs-v0.2.2...core-utils-rs-v0.3.0) - 2024-11-29
+
+### Added
+
+- [**breaking**] adapt for gstreamer

--- a/crates/core-video-rs/CHANGELOG.md
+++ b/crates/core-video-rs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/doom-fish/core-frameworks/compare/core-video-rs-v0.2.2...core-video-rs-v0.3.0) - 2024-11-29
+
+### Added
+
+- [**breaking**] adapt for gstreamer
+
 ## [0.2.2](https://github.com/doom-fish/core-frameworks/compare/core-video-rs-v0.2.1...core-video-rs-v0.2.2) - 2024-11-16
 
 ### Added


### PR DESCRIPTION
## 🤖 New release
* `core-audio-types-rs`: 0.2.2 -> 0.3.0
* `core-media-rs`: 0.2.2 -> 0.3.0 (⚠️ API breaking changes)
* `core-utils-rs`: 0.2.2 -> 0.3.0 (⚠️ API breaking changes)
* `core-video-rs`: 0.2.2 -> 0.3.0 (⚠️ API breaking changes)

### ⚠️ `core-media-rs` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant CMSampleBufferError:CouldNotGetImageBuffer in /private/var/folders/5q/zcc7tkt11f13mhczs1yfd4qc0000gn/T/.tmp77BDaG/core-frameworks/crates/core-media-rs/src/cm_sample_buffer/error.rs:66
```

### ⚠️ `core-utils-rs` breaking changes

```
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/module_missing.ron

Failed in:
  mod core_utils_rs::lock, previously in file /private/var/folders/5q/zcc7tkt11f13mhczs1yfd4qc0000gn/T/.tmpGMcUkS/core-utils-rs/src/lock.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_missing.ron

Failed in:
  struct core_utils_rs::lock::LockGuard, previously in file /private/var/folders/5q/zcc7tkt11f13mhczs1yfd4qc0000gn/T/.tmpGMcUkS/core-utils-rs/src/lock.rs:7
  struct core_utils_rs::lock::MutLockGuard, previously in file /private/var/folders/5q/zcc7tkt11f13mhczs1yfd4qc0000gn/T/.tmpGMcUkS/core-utils-rs/src/lock.rs:9

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_missing.ron

Failed in:
  trait core_utils_rs::lock::MutLockGuardTrait, previously in file /private/var/folders/5q/zcc7tkt11f13mhczs1yfd4qc0000gn/T/.tmpGMcUkS/core-utils-rs/src/lock.rs:52
  trait core_utils_rs::lock::LockGuardTrait, previously in file /private/var/folders/5q/zcc7tkt11f13mhczs1yfd4qc0000gn/T/.tmpGMcUkS/core-utils-rs/src/lock.rs:45
  trait core_utils_rs::lock::MutLockTrait, previously in file /private/var/folders/5q/zcc7tkt11f13mhczs1yfd4qc0000gn/T/.tmpGMcUkS/core-utils-rs/src/lock.rs:49
  trait core_utils_rs::lock::LockTrait, previously in file /private/var/folders/5q/zcc7tkt11f13mhczs1yfd4qc0000gn/T/.tmpGMcUkS/core-utils-rs/src/lock.rs:41
```

### ⚠️ `core-video-rs` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  CVPixelBuffer::internal_lock_base_address, previously in file /private/var/folders/5q/zcc7tkt11f13mhczs1yfd4qc0000gn/T/.tmpGMcUkS/core-video-rs/src/cv_pixel_buffer/internal_lock.rs:16
  CVPixelBuffer::internal_unlock_base_address, previously in file /private/var/folders/5q/zcc7tkt11f13mhczs1yfd4qc0000gn/T/.tmpGMcUkS/core-video-rs/src/cv_pixel_buffer/internal_lock.rs:36
  CVPixelBuffer::internal_base_address, previously in file /private/var/folders/5q/zcc7tkt11f13mhczs1yfd4qc0000gn/T/.tmpGMcUkS/core-video-rs/src/cv_pixel_buffer/internal_lock.rs:55
  CVPixelBuffer::internal_base_address_mut, previously in file /private/var/folders/5q/zcc7tkt11f13mhczs1yfd4qc0000gn/T/.tmpGMcUkS/core-video-rs/src/cv_pixel_buffer/internal_lock.rs:68
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `core-media-rs`
<blockquote>

## [0.3.0](https://github.com/doom-fish/core-frameworks/compare/core-media-rs-v0.2.2...core-media-rs-v0.3.0) - 2024-11-29

### Added

- [**breaking**] adapt for gstreamer
</blockquote>

## `core-utils-rs`
<blockquote>

## [0.3.0](https://github.com/doom-fish/core-frameworks/compare/core-utils-rs-v0.2.2...core-utils-rs-v0.3.0) - 2024-11-29

### Added

- [**breaking**] adapt for gstreamer
</blockquote>

## `core-video-rs`
<blockquote>

## [0.3.0](https://github.com/doom-fish/core-frameworks/compare/core-video-rs-v0.2.2...core-video-rs-v0.3.0) - 2024-11-29

### Added

- [**breaking**] adapt for gstreamer
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).