### PR TITLE
chore: release v0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,17 @@ members = [
 ]
 [workspace.package]
 authors = ["Per Johansson <per@doom.fisn>"]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 repository = "https://github.com/doom-fish/core-frameworks"
 homepage = "https://doom.fish"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-core-audio-types-rs = { path = "crates/core-audio-types-rs", version = "0.3.2" }
-core-media-rs = { path = "crates/core-media-rs", version = "0.3.2" }
-core-video-rs = { path = "crates/core-video-rs", version = "0.3.2" }
-core-utils-rs = { path = "crates/core-utils-rs", version = "0.3.2" }
+core-audio-types-rs = { path = "crates/core-audio-types-rs", version = "0.3.3" }
+core-media-rs = { path = "crates/core-media-rs", version = "0.3.3" }
+core-video-rs = { path = "crates/core-video-rs", version = "0.3.3" }
+core-utils-rs = { path = "crates/core-utils-rs", version = "0.3.3" }
 
 # External dependencies
 core-foundation = "0.10"

--- a/crates/core-media-rs/CHANGELOG.md
+++ b/crates/core-media-rs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/doom-fish/core-frameworks/compare/core-media-rs-v0.3.2...core-media-rs-v0.3.3) - 2024-12-13
+
+### Fixed
+
+- *(CMVideoCodecType)* enable CMVideoCodecType again
+
 ## [0.3.1](https://github.com/doom-fish/core-frameworks/compare/core-media-rs-v0.3.0...core-media-rs-v0.3.1) - 2024-12-13
 
 ### Added


### PR DESCRIPTION
## 🤖 New release
* `core-audio-types-rs`: 0.3.2 -> 0.3.3
* `core-media-rs`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `core-utils-rs`: 0.3.2 -> 0.3.3
* `core-video-rs`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `core-media-rs`
<blockquote>

## [0.3.3](https://github.com/doom-fish/core-frameworks/compare/core-media-rs-v0.3.2...core-media-rs-v0.3.3) - 2024-12-13

### Fixed

- *(CMVideoCodecType)* enable CMVideoCodecType again
</blockquote>

## `core-utils-rs`
<blockquote>

## [0.3.2](https://github.com/doom-fish/core-frameworks/compare/core-utils-rs-v0.3.1...core-utils-rs-v0.3.2) - 2024-12-13

### Fixed

- *(CMVideoCodecType)* const referencing static issue
</blockquote>

## `core-video-rs`
<blockquote>

## [0.3.0](https://github.com/doom-fish/core-frameworks/compare/core-video-rs-v0.2.2...core-video-rs-v0.3.0) - 2024-11-29

### Added

- [**breaking**] adapt for gstreamer
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).