### PR TITLE
feat: extend CVPixelBuffer

### DIFF
--- a/crates/core-video-rs/src/cv_pixel_buffer/internal_lock.rs
+++ b/crates/core-video-rs/src/cv_pixel_buffer/internal_lock.rs
@@ -65,6 +65,27 @@ impl CVPixelBuffer {
             Ok(unsafe { std::slice::from_raw_parts(result, size) })
         }
     }
+    pub(crate) fn internal_base_address_of_plane<'a>(
+        &self,
+        plane_index: u32,
+    ) -> Result<&'a [u8], CVPixelBufferError> {
+        extern "C" {
+            fn CVPixelBufferGetBaseAddressOfPlane(
+                pixelBuffer: CVPixelBufferRef,
+                plane_index: u32,
+            ) -> *mut u8;
+        }
+
+        let result =
+            unsafe { CVPixelBufferGetBaseAddressOfPlane(self.as_concrete_TypeRef(), plane_index) };
+        if result.is_null() {
+            Err(CVPixelBufferError::BaseAddress)
+        } else {
+            let size = (self.internal_bytes_per_row_of_plane(plane_index) * self.internal_height())
+                as usize;
+            Ok(unsafe { std::slice::from_raw_parts(result, size) })
+        }
+    }
     pub(crate) fn internal_base_address_mut<'a>(&self) -> Result<&'a mut [u8], CVPixelBufferError> {
         extern "C" {
             fn CVPixelBufferGetBaseAddress(pixelBuffer: CVPixelBufferRef) -> *mut u8;
@@ -75,6 +96,27 @@ impl CVPixelBuffer {
             Err(CVPixelBufferError::BaseAddress)
         } else {
             let size = (self.internal_bytes_per_row() * self.internal_height()) as usize;
+            Ok(unsafe { std::slice::from_raw_parts_mut(result, size) })
+        }
+    }
+    pub(crate) fn internal_base_address_of_plane_mut<'a>(
+        &self,
+        plane_index: u32,
+    ) -> Result<&'a mut [u8], CVPixelBufferError> {
+        extern "C" {
+            fn CVPixelBufferGetBaseAddressOfPlane(
+                pixelBuffer: CVPixelBufferRef,
+                plane_index: u32,
+            ) -> *mut u8;
+        }
+
+        let result =
+            unsafe { CVPixelBufferGetBaseAddressOfPlane(self.as_concrete_TypeRef(), plane_index) };
+        if result.is_null() {
+            Err(CVPixelBufferError::BaseAddress)
+        } else {
+            let size = (self.internal_bytes_per_row_of_plane(plane_index) * self.internal_height())
+                as usize;
             Ok(unsafe { std::slice::from_raw_parts_mut(result, size) })
         }
     }

--- a/crates/core-video-rs/src/cv_pixel_buffer/internal_props.rs
+++ b/crates/core-video-rs/src/cv_pixel_buffer/internal_props.rs
@@ -19,6 +19,16 @@ impl CVPixelBuffer {
 
         unsafe { CVPixelBufferGetBytesPerRow(self.as_concrete_TypeRef()) }
     }
+    pub(super) fn internal_bytes_per_row_of_plane(&self, plane_index: u32) -> u32 {
+        extern "C" {
+            fn CVPixelBufferGetBytesPerRowOfPlane(
+                pixel_buffer_ref: CVPixelBufferRef,
+                plane_index: u32,
+            ) -> u32;
+        }
+
+        unsafe { CVPixelBufferGetBytesPerRowOfPlane(self.as_concrete_TypeRef(), plane_index) }
+    }
     pub(super) fn internal_width(&self) -> u32 {
         extern "C" {
             fn CVPixelBufferGetWidth(pixel_buffer_ref: CVPixelBufferRef) -> u32;
@@ -32,5 +42,12 @@ impl CVPixelBuffer {
         }
 
         unsafe { CVPixelBufferGetHeight(self.as_concrete_TypeRef()) }
+    }
+    pub(super) fn internal_get_plane_count(&self) -> u32 {
+        extern "C" {
+            fn CVPixelBufferGetPlaneCount(pixel_buffer_ref: CVPixelBufferRef) -> u32;
+        }
+
+        unsafe { CVPixelBufferGetPlaneCount(self.as_concrete_TypeRef()) }
     }
 }

--- a/crates/core-video-rs/src/cv_pixel_buffer/mod.rs
+++ b/crates/core-video-rs/src/cv_pixel_buffer/mod.rs
@@ -23,11 +23,17 @@ impl CVPixelBuffer {
     pub fn get_bytes_per_row(&self) -> u32 {
         self.internal_bytes_per_row()
     }
+    pub fn get_bytes_per_row_of_plane(&self, plane_index: u32) -> u32 {
+        self.internal_bytes_per_row_of_plane(plane_index)
+    }
     pub fn get_width(&self) -> u32 {
         self.internal_width()
     }
     pub fn get_height(&self) -> u32 {
         self.internal_height()
+    }
+    pub fn get_plane_count(&self) -> u32 {
+        self.internal_get_plane_count()
     }
 
     pub fn create(


### PR DESCRIPTION
Adds support for multiple planes per buffer, in particular:
    - Modifies BaseAddressGuard and MutBaseAddressGuard to hold a vector of &[u8], one for each plane.
    - Adds internal_base_address_of_plane and internal_base_address_of_plane_mut.
    - Adds internal_get_plane_count and internal_bytes_per_row_of_plane.