### PR TITLE
fix: AudioBufferList layout

### DIFF
--- a/crates/core-audio-types-rs/src/audio_buffer_list.rs
+++ b/crates/core-audio-types-rs/src/audio_buffer_list.rs
@@ -3,16 +3,16 @@ use crate::audio_buffer::AudioBuffer;
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct AudioBufferList<const SIZE: usize = 8> {
-    number_buffers: usize,
+    number_buffers: u32,
     buffers: [AudioBuffer; SIZE],
 }
 
 impl AudioBufferList {
     pub fn num_buffers(&self) -> usize {
-        self.number_buffers
+        self.number_buffers as usize
     }
     pub fn buffers(&self) -> &[AudioBuffer] {
-        &self.buffers[..self.number_buffers]
+        &self.buffers[..self.number_buffers as usize]
     }
     pub fn get(&self, index: usize) -> Option<&AudioBuffer> {
         self.buffers().get(index)


### PR DESCRIPTION
Fix for AudioBufferList layout errors 

See: https://developer.apple.com/documentation/CoreAudioTypes/AudioBufferList

https://github.com/doom-fish/core-frameworks/blob/main/crates/core-media-rs/src/cm_sample_buffer/internal_audio.rs#L86

Also, I need to point out that there is a UB here, where the audio_buffer_list_ptr is uninitialized, and if the audio_buffer_list_ptr is not populated, it is a UB.

But I've found no easy way to deal with it at the moment, and I'm not aware of any problems at the moment, so I'll have to put it on hold for now.