### PR TITLE
chore: release v0.3.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,17 +8,17 @@ members = [
 ]
 [workspace.package]
 authors = ["Per Johansson <per@doom.fisn>"]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 repository = "https://github.com/doom-fish/core-frameworks"
 homepage = "https://doom.fish"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-core-audio-types-rs = { path = "crates/core-audio-types-rs", version = "0.3.4" }
-core-media-rs = { path = "crates/core-media-rs", version = "0.3.4" }
-core-video-rs = { path = "crates/core-video-rs", version = "0.3.4" }
-core-utils-rs = { path = "crates/core-utils-rs", version = "0.3.4" }
+core-audio-types-rs = { path = "crates/core-audio-types-rs", version = "0.3.5" }
+core-media-rs = { path = "crates/core-media-rs", version = "0.3.5" }
+core-video-rs = { path = "crates/core-video-rs", version = "0.3.5" }
+core-utils-rs = { path = "crates/core-utils-rs", version = "0.3.5" }
 
 # External dependencies
 core-foundation = "0.10"

--- a/crates/core-audio-types-rs/CHANGELOG.md
+++ b/crates/core-audio-types-rs/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.5](https://github.com/doom-fish/core-frameworks/compare/core-audio-types-rs-v0.3.4...core-audio-types-rs-v0.3.5) - 2025-04-22
+
+### Fixed
+
+- AudioBufferList layout


### PR DESCRIPTION



## 🤖 New release

* `core-audio-types-rs`: 0.3.4 -> 0.3.5 (✓ API compatible changes)
* `core-utils-rs`: 0.3.4 -> 0.3.5
* `core-video-rs`: 0.3.4 -> 0.3.5
* `core-media-rs`: 0.3.4 -> 0.3.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `core-audio-types-rs`

<blockquote>

## [0.3.5](https://github.com/doom-fish/core-frameworks/compare/core-audio-types-rs-v0.3.4...core-audio-types-rs-v0.3.5) - 2025-04-22

### Fixed

- AudioBufferList layout
</blockquote>

## `core-utils-rs`

<blockquote>

## [0.3.2](https://github.com/doom-fish/core-frameworks/compare/core-utils-rs-v0.3.1...core-utils-rs-v0.3.2) - 2024-12-13

### Fixed

- *(CMVideoCodecType)* const referencing static issue
</blockquote>

## `core-video-rs`

<blockquote>

## [0.3.4](https://github.com/doom-fish/core-frameworks/compare/core-video-rs-v0.3.3...core-video-rs-v0.3.4) - 2024-12-19

### Added

- extend CVPixelBuffer
</blockquote>

## `core-media-rs`

<blockquote>

## [0.3.4](https://github.com/doom-fish/core-frameworks/compare/core-media-rs-v0.3.3...core-media-rs-v0.3.4) - 2024-12-19

### Added

- make CMTime's members public
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).